### PR TITLE
feat: implement switching between navbars according to login status

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -20,5 +20,6 @@ export async function GET(request: Request) {
   }
 
   // URL to redirect to after sign up process completes
+  // WE NEED TO DECIDE WHERE THIS GOES
   return NextResponse.redirect(`${origin}/protected`);
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -43,8 +43,8 @@ export default async function RootLayout({
           <div className="min-h-screen h-[100svh] flex flex-col ">
             <header className="w-full flex shrink-0 justify-center h-16 bg-gray-300"></header>
             <main className="flex-1 relative">{children}</main>
-            {/* checks if a user is logged in and displays the appropriate navbar */}
-            {!user ? <BottomNavMobileLoggedOut /> : <BottomNavMobileLoggedIn />}
+            {user && <BottomNavMobileLoggedIn />}
+            {!user && <BottomNavMobileLoggedOut />}
           </div>
         </ThemeProvider>
       </body>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,9 @@
 import { Geist } from "next/font/google";
 import { ThemeProvider } from "next-themes";
 import "./globals.css";
-import BottomNavMobile from "@/components/bottom-nav-mobile";
-
-// Icons
-import { HomeIcon } from "@heroicons/react/24/outline";
-import { MapIcon } from "@heroicons/react/24/outline";
-import { UserIcon } from "@heroicons/react/24/outline";
+import BottomNavMobileLoggedIn from "@/components/bottom-nav-mobile-logged-in";
+import BottomNavMobileLoggedOut from "@/components/bottom-nav-mobile-logged-out";
+import { createClient } from "@/utils/supabase/server";
 
 const defaultUrl = process.env.VERCEL_URL
   ? `https://${process.env.VERCEL_URL}`
@@ -22,11 +19,18 @@ const geistSans = Geist({
   subsets: ["latin"],
 });
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const supabase = await createClient();
+
+  // gets information about logged in user
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
   return (
     <html lang="en" suppressHydrationWarning>
       <body className="antialiased" suppressHydrationWarning={true}>
@@ -37,17 +41,10 @@ export default function RootLayout({
           disableTransitionOnChange
         >
           <div className="min-h-screen h-[100svh] flex flex-col ">
-            <header className="w-full flex shrink-0 justify-center h-16 bg-gray-300">
-              SEARCH
-            </header>
+            <header className="w-full flex shrink-0 justify-center h-16 bg-gray-300"></header>
             <main className="flex-1 relative">{children}</main>
-            <BottomNavMobile
-              NavButtons={[
-                { icon: HomeIcon, text: "Home", href: "/" },
-                { icon: MapIcon, text: "Map", href: "/truckmap" },
-                { icon: UserIcon, text: "Account", href: "/profile" },
-              ]}
-            />
+            {/* checks if a user is logged in and displays the appropriate navbar */}
+            {!user ? <BottomNavMobileLoggedOut /> : <BottomNavMobileLoggedIn />}
           </div>
         </ThemeProvider>
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 export default async function Home() {
   return (
     <>
-      <h1>LOCAL TRUCK MAP</h1>
+      <h1>Landing Page...</h1>
     </>
   );
 }

--- a/components/bottom-nav-mobile-logged-in.tsx
+++ b/components/bottom-nav-mobile-logged-in.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import React from "react";
+import BottomNavMobile from "./bottom-nav-mobile";
+
+// Icons
+import { HomeIcon } from "@heroicons/react/24/outline";
+import { MapIcon } from "@heroicons/react/24/outline";
+import { UserIcon } from "@heroicons/react/24/outline";
+
+export default function BottomNavMobileLoggedIn() {
+  return (
+    <BottomNavMobile
+      NavButtons={[
+        { icon: HomeIcon, text: "Home", href: "/" },
+        { icon: MapIcon, text: "Map", href: "/truckmap" },
+        { icon: UserIcon, text: "Account", href: "/profile" },
+      ]}
+    />
+  );
+}

--- a/components/bottom-nav-mobile-logged-out.tsx
+++ b/components/bottom-nav-mobile-logged-out.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import React from "react";
+import BottomNavMobile from "./bottom-nav-mobile";
+
+// Icons
+import { HomeIcon } from "@heroicons/react/24/outline";
+import { MapIcon } from "@heroicons/react/24/outline";
+import { ArrowLeftEndOnRectangleIcon } from "@heroicons/react/24/outline";
+
+export default function BottomNavMobileLoggedOut() {
+  return (
+    <BottomNavMobile
+      NavButtons={[
+        { icon: HomeIcon, text: "Home", href: "/" },
+        { icon: MapIcon, text: "Map", href: "/truckmap" },
+        {
+          icon: ArrowLeftEndOnRectangleIcon,
+          text: "Login",
+          href: "/sign-in",
+        },
+      ]}
+    />
+  );
+}

--- a/components/bottom-nav-mobile.tsx
+++ b/components/bottom-nav-mobile.tsx
@@ -9,6 +9,7 @@ type BottomNavMobileProps = {
 export default function BottomNavMobile({ NavButtons }: BottomNavMobileProps) {
   return (
     <div className="sticky top-[100vh] flex justify-around items-center w-full h-16 bg-gray-300">
+      {/* creates a button for each button passed to the component */}
       {NavButtons.map((NavButton, index) => (
         <NavButtonMobile key={index} NavButton={NavButton} />
       ))}

--- a/components/nav-button-mobile.tsx
+++ b/components/nav-button-mobile.tsx
@@ -1,16 +1,25 @@
 import React from "react";
 import Link from "next/link";
 import { NavButton } from "./global-component-types";
+import { usePathname } from "next/navigation";
+import clsx from "clsx";
 
 type NavButtonMobileProps = {
   NavButton: NavButton;
 };
 
 export default function NavButtonMobile({ NavButton }: NavButtonMobileProps) {
+  const pathname = usePathname();
+
   const Icon = NavButton.icon;
   return (
     <Link href={NavButton.href}>
-      <div className="flex flex-col justify-center items-center w-[80px] h-[50px]">
+      <div
+        className={clsx(
+          "flex flex-col justify-center items-center w-[80px] h-[50px]",
+          { "bg-gray-400": pathname === NavButton.href }
+        )}
+      >
         <Icon className="size-6 " />
         <p>{NavButton.text}</p>
       </div>

--- a/utils/supabase/middleware.ts
+++ b/utils/supabase/middleware.ts
@@ -22,17 +22,17 @@ export const updateSession = async (request: NextRequest) => {
           },
           setAll(cookiesToSet) {
             cookiesToSet.forEach(({ name, value }) =>
-              request.cookies.set(name, value),
+              request.cookies.set(name, value)
             );
             response = NextResponse.next({
               request,
             });
             cookiesToSet.forEach(({ name, value, options }) =>
-              response.cookies.set(name, value, options),
+              response.cookies.set(name, value, options)
             );
           },
         },
-      },
+      }
     );
 
     // This will refresh session if expired - required for Server Components
@@ -44,9 +44,10 @@ export const updateSession = async (request: NextRequest) => {
       return NextResponse.redirect(new URL("/sign-in", request.url));
     }
 
-    if (request.nextUrl.pathname === "/" && !user.error) {
-      return NextResponse.redirect(new URL("/protected", request.url));
-    }
+    // I DON'T KNOW IF WE NEED THIS CODE, IT SEEMS TO REDIRECT THE HOMEPAGE WHEN LOGGED IN
+    // if (request.nextUrl.pathname === "/" && !user.error) {
+    //   return NextResponse.redirect(new URL("/protected", request.url));
+    // }
 
     return response;
   } catch (e) {


### PR DESCRIPTION
The correct navbar is now displayed when a user isn't logged in and the current pages button is highlighted so the user knows which page they are on

![image](https://github.com/user-attachments/assets/20148126-1db7-4e96-98ad-5502ec17d464)
![image](https://github.com/user-attachments/assets/50424962-4fb5-4061-be42-f9878f305641)
