### PR TITLE
feat: implement food truck cards for landing page and favorites tab

### DIFF
--- a/app/database-actions.ts
+++ b/app/database-actions.ts
@@ -16,7 +16,9 @@ export const getFavoriteTruck = async (profileId: string) => {
 
   const { data, error } = await supabase
     .from("favorite_trucks")
-    .select("food_truck_id, profiles_id, food_truck_profiles(name)")
+    .select(
+      "food_truck_id, profiles_id, food_truck_profiles(name, food_style, avatar)"
+    )
     .eq("profiles_id", profileId);
 
   if (error) return [];

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,18 +1,14 @@
-import FoodTruckCard from "@/components/food-truck/food-truck-card";
 import React from "react";
 import { getFoodTruckData } from "@/app/database-actions";
+import FoodTruckCardLanding from "@/components/food-truck/food-truck-card-landing";
 
 export default async function Home() {
   const foodTruckData = await getFoodTruckData();
 
   return (
-    <div className="pb-16">
+    <div className="flex flex-col gap-4 p-3 bg-muted">
       {foodTruckData?.map((foodTruck) => (
-        <FoodTruckCard
-          key={foodTruck.id}
-          foodTruck={foodTruck}
-          context={"landing"}
-        />
+        <FoodTruckCardLanding key={foodTruck.id} foodTruck={foodTruck} />
       ))}
     </div>
   );

--- a/components/food-truck/food-truck-card-landing.tsx
+++ b/components/food-truck/food-truck-card-landing.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { Truck } from "./../global-component-types";
+import Image from "next/image";
+import { TiArrowForward } from "react-icons/ti";
+import Link from "next/link";
+
+type FoodTruckCardProps = {
+  foodTruck: Truck;
+};
+
+export default function FoodTruckCardLanding({
+  foodTruck,
+}: FoodTruckCardProps) {
+  return (
+    <div className="rounded-xl bg-background overflow-clip shadow-md">
+      <Image
+        className="h-[200px] object-cover"
+        src={foodTruck.avatar}
+        alt="Picture of a food truck"
+        width={600}
+        height={600}
+      ></Image>
+      <div className="flex">
+        <div className="p-3">
+          <h2 className="text-lg font-semibold text-primary">
+            {foodTruck.name}
+          </h2>
+          <p>{foodTruck.food_style}</p>
+        </div>
+        {/* we need to fix the link here currently just the map */}
+        <Link
+          href="/truck-map"
+          className="flex justify-center items-center text-background text-2xl ml-auto bg-primary w-16"
+        >
+          <TiArrowForward />
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/components/food-truck/food-truck-card-profile.tsx
+++ b/components/food-truck/food-truck-card-profile.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { Favorite, Truck } from "./../global-component-types";
+import Image from "next/image";
+import { TiArrowForward } from "react-icons/ti";
+import Link from "next/link";
+
+type FoodTruckCardProps = {
+  foodTruck: Favorite;
+};
+
+export default function FoodTruckCardProfile({
+  foodTruck,
+}: FoodTruckCardProps) {
+  return (
+    <div className="flex flex-col rounded-xl bg-background overflow-clip shadow-md">
+      <Image
+        className="h-[100px] object-cover"
+        src={foodTruck.food_truck_profiles.avatar}
+        alt="Picture of a food truck"
+        width={600}
+        height={600}
+      ></Image>
+      <div className="flex flex-col grow">
+        <div className="p-3">
+          <h2 className="text-md font-semibold text-primary">
+            {foodTruck.food_truck_profiles.name}
+          </h2>
+          <p className="text-sm">{foodTruck.food_truck_profiles.food_style}</p>
+        </div>
+        {/* we need to fix the link here currently just the map */}
+        <Link
+          href="/truck-map"
+          className=" flex justify-center items-center text-background text-2xl mt-auto bg-primary w-full h-10"
+        >
+          <TiArrowForward />
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/components/global-component-types.d.ts
+++ b/components/global-component-types.d.ts
@@ -17,7 +17,7 @@ type Truck = {
 type Favorite = {
   food_truck_id: number;
   profile_id: string;
-  food_truck_profiles: { name: string };
+  food_truck_profiles: Truck;
 };
 
 type Location = {

--- a/components/user-profile.tsx
+++ b/components/user-profile.tsx
@@ -6,14 +6,16 @@ import { UserMetadata } from "@supabase/supabase-js";
 import { getFavoriteTruck } from "@/app/database-actions";
 import FavoriteTruckCard from "./food-truck/favorite-truck-card";
 import Image from "next/image";
-
+import FoodTruckCardProfile from "./food-truck/food-truck-card-profile";
 
 export default function UserProfile() {
   const supabase = createClient();
 
   const [user, setUser] = useState<UserMetadata | undefined>(undefined);
   const [favoriteTrucks, setFavoriteTrucks] = useState<any[]>([]);
-  const [activeTab, setActiveTab] = useState<"favorites" | "sightings" | "reviews">("favorites");
+  const [activeTab, setActiveTab] = useState<
+    "favorites" | "sightings" | "reviews"
+  >("favorites");
 
   useEffect(() => {
     (async () => {
@@ -33,7 +35,7 @@ export default function UserProfile() {
         }
       }
     };
-  
+
     fetchFavorites(); // Call the async function
   }, [activeTab]);
 
@@ -41,74 +43,69 @@ export default function UserProfile() {
     <div className="p-4">
       {/* center profile image */}
       <div className="flex justify-center mb-2">
-
         {/* from joe code (food truck card) */}
-      <Image
-        className="rounded-full items-center h-[125px] w-[125px] object-cover"
-        src={"https://qieslzondvbkbokewujq.supabase.co/storage/v1/object/public/BiteMap//avatar.png"}
-        alt="Profile picture"
-        width={200}
-        height={200}
-      ></Image>
+        <Image
+          className="rounded-full items-center h-[125px] w-[125px] object-cover"
+          src={
+            "https://qieslzondvbkbokewujq.supabase.co/storage/v1/object/public/BiteMap//avatar.png"
+          }
+          alt="Profile picture"
+          width={200}
+          height={200}
+        ></Image>
       </div>
-      {/* <h1>Personal Details</h1> */}
       <div>
-        <p className="flex justify-center mb-2">
-          {" "}
-          <span className="font-semibold">Name:</span>{" "}
+        <p className="flex justify-center text-2xl font-semibold text-primary">
           {user && user.display_name}
         </p>
-        <p className="flex justify-center mb-2">
-          {" "}
-          <span className="font-semibold">Email:</span> {user && user.email}
-        </p>
+        <p className="flex justify-center mb-2">{user && user.email}</p>
       </div>
 
       <div className="border-b border-gray-200 mt-4">
-    <nav className="flex -mb-px">
-      {["favorites", "sightings", "reviews"].map((tab) => (
-        <button
-          key={tab}
-          onClick={() => setActiveTab(tab as any)}
-          className={`flex-1 px-4 py-3 text-center text-sm font-medium ${
-            activeTab === tab
-              ? "border-b-2 border-primary text-primary"
-              : "text-gray-500 hover:text-gray-700 hover:border-gray-300"
-          } transition-colors duration-200`}
-        >
-          {tab.charAt(0).toUpperCase() + tab.slice(1)}
-        </button>
-      ))}
-    </nav>
-  </div>
-  <div className="p-6">
-      {activeTab === "favorites" && (
-        <div>
-          {favoriteTrucks.length > 0 ? (
-            favoriteTrucks.map((truck) => (
-              <FavoriteTruckCard
-                key={truck.food_truck_id}
-                favoriteTruck={truck}
-              />
-            ))
-          ) : (
-            <p>No favorite trucks found</p>
-          )}
+        <nav className="flex -mb-px">
+          {["favorites", "sightings", "reviews"].map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(tab as any)}
+              className={`flex-1 px-4 py-3 text-center text-sm font-medium ${
+                activeTab === tab
+                  ? "border-b-2 border-primary text-primary"
+                  : "text-gray-500 hover:text-gray-700 hover:border-gray-300"
+              } transition-colors duration-200`}
+            >
+              {tab.charAt(0).toUpperCase() + tab.slice(1)}
+            </button>
+          ))}
+        </nav>
+      </div>
+      <div className="pt-3">
+        {activeTab === "favorites" && (
+          <div className="grid grid-cols-2 gap-4">
+            {favoriteTrucks.length > 0 ? (
+              favoriteTrucks.map((truck) => (
+                <FoodTruckCardProfile
+                  key={truck.food_truck_id}
+                  foodTruck={truck}
+                />
+              ))
+            ) : (
+              <p>No favorite trucks found</p>
+            )}
           </div>
-      )}
+        )}
 
-      {activeTab === "sightings" && (
-        <div>
+        {activeTab === "sightings" && (
+          <div>
             <p>No sighting available</p>
-        </div>
-      )}
+          </div>
+        )}
 
-      {activeTab === "reviews" && (
-        <div>
-          <p>No reviews available</p>
-        </div>
-      )}
+        {activeTab === "reviews" && (
+          <div>
+            <p>No reviews available</p>
+          </div>
+        )}
+      </div>
     </div>
-</div>
-)}
-
+  );
+}


### PR DESCRIPTION
Added two new components. They are very similar but I think for now this approach keeps it simple and easy to understand rather than having to pass context as a prop.

Both components handle displaying food truck cards. One displays a larger card on the landing page the other displays a smaller card for each favorite truck under the favorites tab in the profile page.

![image](https://github.com/user-attachments/assets/6969921c-4a74-4686-86d1-7fa17d857770)
![image](https://github.com/user-attachments/assets/ba9c56d0-39ff-4014-9c72-6cd4be0dcd83)


