### PR TITLE
feat: style sighting card and display different button according to current route

### DIFF
--- a/components/food-truck/food-truck-card-landing.tsx
+++ b/components/food-truck/food-truck-card-landing.tsx
@@ -12,7 +12,7 @@ export default function FoodTruckCardLanding({
   foodTruck,
 }: FoodTruckCardProps) {
   return (
-    <div className="rounded-xl bg-background overflow-clip shadow-md">
+    <div className="rounded-xl bg-background overflow-clip shadow-md ring-1 ring-primary">
       <Image
         className="h-[200px] object-cover"
         src={foodTruck.avatar}

--- a/components/food-truck/food-truck-card-profile.tsx
+++ b/components/food-truck/food-truck-card-profile.tsx
@@ -13,7 +13,7 @@ export default function FoodTruckCardProfile({
   foodTruck,
 }: FoodTruckCardProps) {
   return (
-    <div className="relative flex flex-col rounded-xl bg-background overflow-clip shadow-md">
+    <div className="relative flex flex-col rounded-xl bg-background overflow-clip shadow-md ring-1 ring-primary">
       <IoMdHeart className="absolute left-1 top-1 text-primary text-xl shadow-lg" />
       <Image
         className="h-[100px] object-cover"

--- a/components/food-truck/food-truck-profile.tsx
+++ b/components/food-truck/food-truck-profile.tsx
@@ -8,12 +8,15 @@ import {
   getSightingByTruckId,
 } from "@/app/database-actions";
 import SightingCard from "./sighting-card";
+import { usePathname } from "next/navigation";
 
 type FoodTruckProfileProps = {
   truckId: number;
 };
 
 export default function FoodTruckProfile({ truckId }: FoodTruckProfileProps) {
+  const pathname = usePathname();
+
   const [activeTab, setActiveTab] = useState<"sightings" | "reviews">(
     "sightings"
   );
@@ -77,8 +80,7 @@ export default function FoodTruckProfile({ truckId }: FoodTruckProfileProps) {
       </div>
       <div className="pt-3">
         {activeTab === "sightings" && (
-          <div>
-            {/* need to fetch sighting data */}
+          <div className="flex flex-col gap-y-2">
             {sightings ? (
               sightings.map((sighting) => (
                 <SightingCard key={sighting.id} sightingData={sighting} />
@@ -91,7 +93,7 @@ export default function FoodTruckProfile({ truckId }: FoodTruckProfileProps) {
 
         {activeTab === "reviews" && (
           <div>
-            <p>TEST TAB 2</p>
+            <p>No reviews available</p>
           </div>
         )}
       </div>

--- a/components/food-truck/sighting-card.tsx
+++ b/components/food-truck/sighting-card.tsx
@@ -1,21 +1,42 @@
 import React from "react";
 import { Sighting } from "../global-component-types";
+import Link from "next/link";
+import { TiArrowForward } from "react-icons/ti";
+import { FaPlus } from "react-icons/fa";
+import { usePathname } from "next/navigation";
 
 type SightingCardProps = {
   sightingData: Sighting;
 };
 
 export default function SightingCard({ sightingData }: SightingCardProps) {
+  const pathname = usePathname();
+
   return (
-    <div className="rounded-xl bg-background overflow-clip shadow-md ring-1 ring-primary">
-      <div className="flex">
-        <div className="p-2">
-          <h2 className="text-lg font-semibold text-primary">
-            {sightingData.food_truck_profiles.name}
-          </h2>
-          <p>{sightingData.location}</p>
-        </div>
+    <div className="flex rounded-xl bg-background overflow-clip shadow-md ring-1 ring-primary">
+      <div className="grow overflow-hidden px-2 py-1">
+        <h2 className="text-lg font-semibold text-primary">
+          {sightingData.food_truck_profiles.name}
+        </h2>
+        <p className="truncate">{sightingData.location}</p>
       </div>
+      {pathname === "/user-profile" ? (
+        <Link
+          href={`/truck-profile/${sightingData.food_truck_id}`}
+          className=" flex justify-center items-center text-background text-2xl bg-primary w-20"
+        >
+          <TiArrowForward />
+        </Link>
+      ) : (
+        <button
+          onClick={() => {
+            console.log("Confirm Sighting");
+          }}
+          className=" flex justify-center items-center text-background text-2xl bg-primary w-20"
+        >
+          <FaPlus size={16} />
+        </button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Styled the sighting card to match the rest of the site and changed which button is displayed according to the current route using `usePathname`. We ideally want to change what information is displaying for each route too.

![image](https://github.com/user-attachments/assets/a1fda30e-74cc-4fe4-9b0a-3a810a6ef937)
![image](https://github.com/user-attachments/assets/657fa2d2-c094-44a6-abb2-2cbcda563c31)

