### PR TITLE
Feat/redirect to sign in

### DIFF
--- a/app/(auth-pages)/sign-in/page.tsx
+++ b/app/(auth-pages)/sign-in/page.tsx
@@ -4,9 +4,11 @@ import { SubmitButton } from "@/components/submit-button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import Link from "next/link";
+import SignInToast from "@/components/sign-in-toast";
 
 export default async function Login(props: { searchParams: Promise<Message> }) {
   const searchParams = await props.searchParams;
+
   return (
     <form className="flex flex-col min-w-64 max-w-64 mx-auto">
       <h1 className="text-2xl font-medium">Sign in</h1>
@@ -37,7 +39,12 @@ export default async function Login(props: { searchParams: Promise<Message> }) {
         <SubmitButton pendingText="Signing In..." formAction={signInAction}>
           Sign in
         </SubmitButton>
-        <FormMessage message={searchParams} />
+        {"error" in searchParams && searchParams.error !== "Not signed in" && (
+          <FormMessage message={searchParams} />
+        )}
+        {"error" in searchParams && searchParams.error === "Not signed in" && (
+          <SignInToast message={searchParams.error} />
+        )}
       </div>
     </form>
   );

--- a/components/map/map.tsx
+++ b/components/map/map.tsx
@@ -303,6 +303,7 @@ export default function Map() {
             {selectedSighting && (
               <div className="absolute flex flex-col h-fit w-fit justify-center items-center top-16 bg-white rounded-xl border border-gray-300">
                 <SightingConfirmCard
+                  user={user}
                   sighting={selectedSighting}
                   setSelectedSighting={setSelectedSighting}
                 />

--- a/components/map/map.tsx
+++ b/components/map/map.tsx
@@ -35,6 +35,7 @@ const libs: Library[] = ["core", "maps", "places", "marker", "geocoding"];
 
 export default function Map() {
   const router = useRouter();
+
   const supabase = createClient();
 
   // references

--- a/components/map/map.tsx
+++ b/components/map/map.tsx
@@ -28,12 +28,13 @@ import { ToastContainer } from "react-toastify";
 import { createToast } from "@/utils/toast";
 import { createClient } from "@/utils/supabase/client";
 import { UserMetadata } from "@supabase/supabase-js";
-import { redirect } from "next/navigation";
+import { useRouter } from "next/navigation";
 
 // Load api library
 const libs: Library[] = ["core", "maps", "places", "marker", "geocoding"];
 
 export default function Map() {
+  const router = useRouter();
   const supabase = createClient();
 
   // references
@@ -359,7 +360,7 @@ export default function Map() {
             className="absolute bottom-0 right-0 m-3 inline-flex items-center justify-center bg-primary rounded-full w-14 h-14"
             onClick={() => {
               if (!user) {
-                return redirect("/sign-in?error=Not signed in");
+                return router.push("/sign-in?error=Not signed in");
               }
               handleToggleAddButton();
             }}

--- a/components/map/sighting-confirm-card.tsx
+++ b/components/map/sighting-confirm-card.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useEffect, useState } from "react";
 import { Sighting, Truck } from "../global-component-types";
 import {
@@ -5,10 +7,14 @@ import {
   getFoodTruckDataById,
 } from "@/app/database-actions";
 import Link from "next/link";
+import { UserMetadata } from "@supabase/supabase-js";
+
 type SightingConfirmCardProps = {
   sighting: Sighting;
   setSelectedSighting: Function;
+  user: UserMetadata | undefined;
 };
+
 export default function SightingConfirmCard({
   sighting,
   setSelectedSighting,

--- a/components/map/sighting-confirm-card.tsx
+++ b/components/map/sighting-confirm-card.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/app/database-actions";
 import Link from "next/link";
 import { UserMetadata } from "@supabase/supabase-js";
+import { redirect } from "next/navigation";
 
 type SightingConfirmCardProps = {
   sighting: Sighting;
@@ -18,6 +19,7 @@ type SightingConfirmCardProps = {
 export default function SightingConfirmCard({
   sighting,
   setSelectedSighting,
+  user,
   //   set toggle this card display
 }: SightingConfirmCardProps) {
   const [truck, setTruck] = useState<Truck>();
@@ -48,6 +50,10 @@ export default function SightingConfirmCard({
         <button
           className="h-full w-full"
           onClick={async () => {
+            if (!user) {
+              return redirect("/sign-in");
+            }
+
             const data = await addSightingConfirmation(
               sighting.id,
               sighting.food_truck_id

--- a/components/map/sighting-confirm-card.tsx
+++ b/components/map/sighting-confirm-card.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/app/database-actions";
 import Link from "next/link";
 import { UserMetadata } from "@supabase/supabase-js";
-import { redirect } from "next/navigation";
+import { useRouter } from "next/navigation";
 
 import { IoMdClose } from "react-icons/io";
 type SightingConfirmCardProps = {
@@ -25,7 +25,10 @@ export default function SightingConfirmCard({
   user,
   //   set toggle this card display
 }: SightingConfirmCardProps) {
+  const router = useRouter();
+
   const [truck, setTruck] = useState<Truck>();
+
   useEffect(() => {
     const getTruck = async () => {
       const truck = await getFoodTruckDataById(sighting.food_truck_id);
@@ -33,6 +36,7 @@ export default function SightingConfirmCard({
     };
     getTruck();
   }, []);
+
   return (
     <div className="h-64 w-80 justify-center items-center flex flex-col">
       <div className="w-full absolute h-9 top-0 flex flex-row-reverse ">
@@ -61,7 +65,7 @@ export default function SightingConfirmCard({
           className="h-full w-full"
           onClick={async () => {
             if (!user) {
-              return redirect("/sign-in");
+              return router.push("/sign-in?error=Not signed in");
             }
 
             const data = await addSightingConfirmation(

--- a/components/sign-in-toast.tsx
+++ b/components/sign-in-toast.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { createToast } from "@/utils/toast";
+import React, { useState, useEffect } from "react";
+import { ToastContainer } from "react-toastify";
+
+type SignInToastProps = {
+  message: string;
+};
+
+export default function SignInToast({ message }: SignInToastProps) {
+  const [toastMessage, setToastMessage] = useState<string>("");
+
+  useEffect(() => {
+    if (message === "Not signed in") {
+      setToastMessage("You must be signed in to take that action");
+    }
+  }, []);
+
+  useEffect(() => {
+    if (toastMessage !== "") {
+      const signInToast = createToast(toastMessage, "error");
+      signInToast && signInToast();
+    }
+  }, [toastMessage]);
+
+  return <ToastContainer />;
+}


### PR DESCRIPTION
Closes #77 

I added redirects to the sign in page for functionality we want available to only logged in users.

I used router rather than redirect in client pages as i was getting strange errors. It seems it is best to use router client side.

When the user tries to so something that requires them to be logged in they are redirected to the sign in page and shown a toast error message.

I decided to hide the favorite button on the truck profile pages as the colour wasn't working as expected (it is always red rather than gray)

![image](https://github.com/user-attachments/assets/2b3a70f8-1758-4209-b77f-27d008f49dec)
