### PR TITLE
Feat/test order truck list

### DIFF
--- a/app/database-actions.ts
+++ b/app/database-actions.ts
@@ -77,10 +77,13 @@ export const addProfileImageToFoodTruck = async (
     );
 };
 
-// gets information about all food trucks
+// gets information about all food trucks in alphabetical order
 export const getFoodTruckData = async () => {
   const supabase = await createClient();
-  const { data, error } = await supabase.from("food_truck_profiles").select();
+  const { data, error } = await supabase
+    .from("food_truck_profiles")
+    .select()
+    .order("name", { ascending: true }); // orders alphabetically
 
   if (error) console.error("Error fetching all food truck data", error);
 

--- a/components/map/add-sighting.tsx
+++ b/components/map/add-sighting.tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 import { addSighting } from "@/app/database-actions";
 import { getLocation } from "./geo-utils";
 import { Truck, Location } from "../global-component-types";
-import { getNearbyTruck } from "@/app/database-actions";
+import { getNearbyTruck, getFoodTruckData } from "@/app/database-actions";
 import { Input } from "../ui/input";
 import { FaSpinner } from "react-icons/fa";
 import { IoMdClose } from "react-icons/io";
@@ -55,11 +55,10 @@ export default function AddSighting({
     // default to fetch a large radius
     const fetchTruck = async () => {
       if (sightingLocation) {
-        const data = (await getNearbyTruck(
-          sightingLocation?.lat,
-          sightingLocation?.lng,
-          null
-        )) as Truck[];
+        //
+
+        const data = (await getFoodTruckData()) as Truck[];
+
         if (data?.length) {
           setTrucks(data);
         }
@@ -109,7 +108,7 @@ export default function AddSighting({
                     {/* link go to truck profile or get all sighitng? */}
                     <div className="flex flex-row items-start h-full w-full  bg-white border border-gray-200 rounded-xl shadow-sm   hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700">
                       <Image
-                        className="m-3 object-cover rounded-t-lg  md:h-auto md:w-48 md:rounded-none md:rounded-s-lg items-start"
+                        className="m-3 h-[60px] w-[60px] object-cover rounded-t-lg  md:h-auto md:w-48 md:rounded-none md:rounded-s-lg items-start"
                         src={truck.avatar}
                         alt="Image of a food truck"
                         width={60}
@@ -122,9 +121,9 @@ export default function AddSighting({
                         <p className="mb-1 font-normal text-gray-700 dark:text-gray-400">
                           {truck.food_style}
                         </p>
-                        <p className="mb-1 font-normal text-gray-700 dark:text-gray-400">
+                        {/* <p className="mb-1 font-normal text-gray-700 dark:text-gray-400">
                           {` ${Math.floor(truck.nearest_dist_meters)} meters`}
-                        </p>
+                        </p> */}
                       </div>
                     </div>
                   </li>

--- a/components/map/add-sighting.tsx
+++ b/components/map/add-sighting.tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 import { addSighting } from "@/app/database-actions";
 import { getLocation } from "./geo-utils";
 import { Truck, Location } from "../global-component-types";
-import { getNearbyTruck, getFoodTruckData } from "@/app/database-actions";
+import { getFoodTruckData } from "@/app/database-actions";
 import { Input } from "../ui/input";
 import { FaSpinner } from "react-icons/fa";
 import { IoMdClose } from "react-icons/io";
@@ -106,7 +106,7 @@ export default function AddSighting({
                     }}
                   >
                     {/* link go to truck profile or get all sighitng? */}
-                    <div className="flex flex-row items-start h-full w-full  bg-white border border-gray-200 rounded-xl shadow-sm   hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700">
+                    <div className="flex flex-row items-center h-full w-full  bg-white border border-gray-200 rounded-xl shadow-sm   hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700">
                       <Image
                         className="m-3 h-[60px] w-[60px] object-cover rounded-t-lg  md:h-auto md:w-48 md:rounded-none md:rounded-s-lg items-start"
                         src={truck.avatar}
@@ -121,9 +121,6 @@ export default function AddSighting({
                         <p className="mb-1 font-normal text-gray-700 dark:text-gray-400">
                           {truck.food_style}
                         </p>
-                        {/* <p className="mb-1 font-normal text-gray-700 dark:text-gray-400">
-                          {` ${Math.floor(truck.nearest_dist_meters)} meters`}
-                        </p> */}
                       </div>
                     </div>
                   </li>
@@ -131,7 +128,7 @@ export default function AddSighting({
               })}
               {searchItem === "" && (
                 <>
-                  <p>
+                  <p className="pl-2">
                     Can't find the truck you're looking for? You can add one
                     below.
                   </p>
@@ -151,7 +148,9 @@ export default function AddSighting({
             <>
               {!loadingTrucks ? (
                 <>
-                  <p>No trucks match your search. You can add one below.</p>
+                  <p className="pl-2">
+                    No trucks match your search. You can add one below.
+                  </p>
                   <button
                     className="mt-3 relative ml-2 mr-2 bg-primary p-2 text-background border border-gray-300 rounded-xl flex-none h-9 w-64 flex justify-center items-center text-sm"
                     onClick={() => {


### PR DESCRIPTION
Closes #101 

Displays the truck list in alphabetical order so users can browse trucks more easily. I removed the distance as this isn't really important when adding a new sighting. I also fixed how the images display and made some very minor styling changes.

![image](https://github.com/user-attachments/assets/d012033b-8afb-404e-a80c-42e2a9b2b90b)
