### PR TITLE
Feat/location denied

### DIFF
--- a/app/database-actions.ts
+++ b/app/database-actions.ts
@@ -90,6 +90,20 @@ export const getFoodTruckData = async () => {
   return data;
 };
 
+// gets information about 10 most recently added trucks
+export const getFoodNewTrucks = async () => {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("food_truck_profiles")
+    .select()
+    .order("id", { ascending: true })
+    .limit(10); // orders alphabetically
+
+  if (error) console.error("Error fetching all food truck data", error);
+
+  return data;
+};
+
 // gets information for a given food truck by ID
 export const getFoodTruckDataById = async (truckId: number) => {
   const supabase = await createClient();

--- a/components/food-truck/food-truck-card-landing.tsx
+++ b/components/food-truck/food-truck-card-landing.tsx
@@ -8,6 +8,7 @@ import { getNearbyTruck, getFoodNewTrucks } from "@/app/database-actions";
 import { getLocation } from "../map/geo-utils";
 import { createToast } from "@/utils/toast";
 import { ToastContainer } from "react-toastify";
+import FoodTruckCardRecent from "./food-truck-card-recent";
 
 type FoodTruckCardProps = {
   // foodTruck: Truck;
@@ -25,7 +26,7 @@ export default function FoodTruckCardLanding(
   const [locationDenied, setLocationDenied] = useState<boolean>(false);
 
   const locationToast = createToast(
-    "Location permissions denied! This app relies heavily on geolocation. Please consider granting location access. Refresh to grant access.",
+    "Location permissions denied! This app relies heavily on geolocation. Please consider refreshing to grant location access.",
     "error",
     10000
   );
@@ -71,7 +72,7 @@ export default function FoodTruckCardLanding(
               <FaSpinner className="animate-[spin_2s_ease-in-out_infinite] text-primary" />
             </p>
           ) : trucks?.length === 0 || !trucks ? (
-            <p>No food trucks found in your area.</p>
+            <FoodTruckCardRecent trucks={newTrucks} />
           ) : (
             <>
               <h1 className="text-xl text-primary">
@@ -112,40 +113,7 @@ export default function FoodTruckCardLanding(
             </>
           )
         ) : (
-          <>
-            <h1 className="text-xl text-primary">
-              <strong>Recently Added Food Trucks You Might Like</strong>
-            </h1>
-            {/* display recently added trucks */}
-            {newTrucks?.map((truck) => {
-              return (
-                <div key={truck.id}>
-                  <Link href={`/truck-profile/${truck.id}`}>
-                    <div className="rounded-xl bg-background overflow-clip shadow-md ring-1 ring-primary">
-                      <Image
-                        className="h-[200px] object-cover"
-                        src={truck.avatar}
-                        alt="Picture of a food truck"
-                        width={600}
-                        height={600}
-                      ></Image>
-                      <div className="flex flex-row">
-                        <div className="relative w-1/2 pt-3 pb-3 pl-3">
-                          <h2 className="text-lg font-semibold text-primary">
-                            {truck.name}
-                          </h2>
-                          <p>{truck.food_style}</p>
-                        </div>
-                        <div className="flex justify-center items-center text-background text-2xl ml-auto bg-primary w-16">
-                          <FaArrowRight />
-                        </div>
-                      </div>
-                    </div>
-                  </Link>
-                </div>
-              );
-            })}
-          </>
+          <FoodTruckCardRecent trucks={newTrucks} />
         )}
       </div>
       <ToastContainer />

--- a/components/food-truck/food-truck-card-landing.tsx
+++ b/components/food-truck/food-truck-card-landing.tsx
@@ -18,10 +18,15 @@ export default function FoodTruckCardLanding(
   const [location, setLocation] = useState<Location | null>();
   const [trucks, setTrucks] = useState<any[]>();
   const [loading, setLoading] = useState(true);
+  const [locationDenied, setLocationDenied] = useState<boolean>(false);
 
   useEffect(() => {
-    getLocation(setLocation);
+    getLocation(setLocation, setLocationDenied);
   }, []);
+
+  useEffect(() => {
+    console.log("Location denied", locationDenied);
+  }, [locationDenied]);
 
   useEffect(() => {
     const fetchTruck = async () => {
@@ -44,44 +49,52 @@ export default function FoodTruckCardLanding(
       <h1 className="text-xl text-primary">
         <strong>Nearby Food Trucks You Might Like</strong>
       </h1>
-      {loading ? (
-        <p>Loading nearby food trucks ...</p>
-      ) : trucks?.length === 0 || !trucks ? (
-        <p>No food trucks found in your area.</p>
-      ) : (
-        trucks.map((truck) => {
-          return (
-            <div key={truck.id}>
-              <Link href={`/truck-profile/${truck.id}`}>
-                <div className="rounded-xl bg-background overflow-clip shadow-md ring-1 ring-primary">
-                  <Image
-                    className="h-[200px] object-cover"
-                    src={truck.avatar}
-                    alt="Picture of a food truck"
-                    width={600}
-                    height={600}
-                  ></Image>
-                  <div className="flex flex-row">
-                    {/* <div className="p-3"> */}
-                    <div className="relative w-1/2 pt-3 pb-3 pl-3">
-                      <h2 className="text-lg font-semibold text-primary">
-                        {truck.name}
-                      </h2>
-                      <p>{truck.food_style}</p>
-                    </div>
-                    <div className="relative w-1/2 pt-3 pb-3 pr-3">
-                      <p className="text-sm m-1">{`${Math.floor(truck.nearest_dist_meters)} meters from you`}</p>
-                    </div>
-                    {/* we need to fix the link here currently just the map */}
-                    <div className="flex justify-center items-center text-background text-2xl ml-auto bg-primary w-16">
-                      <FaArrowRight />
+
+      {!locationDenied ? (
+        loading ? (
+          <p>Loading nearby food trucks...</p>
+        ) : trucks?.length === 0 || !trucks ? (
+          <p>No food trucks found in your area.</p>
+        ) : (
+          trucks.map((truck) => {
+            return (
+              <div key={truck.id}>
+                <Link href={`/truck-profile/${truck.id}`}>
+                  <div className="rounded-xl bg-background overflow-clip shadow-md ring-1 ring-primary">
+                    <Image
+                      className="h-[200px] object-cover"
+                      src={truck.avatar}
+                      alt="Picture of a food truck"
+                      width={600}
+                      height={600}
+                    ></Image>
+                    <div className="flex flex-row">
+                      {/* <div className="p-3"> */}
+                      <div className="relative w-1/2 pt-3 pb-3 pl-3">
+                        <h2 className="text-lg font-semibold text-primary">
+                          {truck.name}
+                        </h2>
+                        <p>{truck.food_style}</p>
+                      </div>
+                      <div className="relative w-1/2 pt-3 pb-3 pr-3">
+                        <p className="text-sm m-1">{`${Math.floor(truck.nearest_dist_meters)} meters from you`}</p>
+                      </div>
+                      {/* we need to fix the link here currently just the map */}
+                      <div className="flex justify-center items-center text-background text-2xl ml-auto bg-primary w-16">
+                        <FaArrowRight />
+                      </div>
                     </div>
                   </div>
-                </div>
-              </Link>
-            </div>
-          );
-        })
+                </Link>
+              </div>
+            );
+          })
+        )
+      ) : (
+        <p>
+          This web app relies heavily on geolocation. Please consider granting
+          access to your devices location
+        </p>
       )}
     </div>
   );

--- a/components/food-truck/food-truck-card-landing.tsx
+++ b/components/food-truck/food-truck-card-landing.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from "react";
 import { Truck, Location } from "./../global-component-types";
 import Image from "next/image";
 import Link from "next/link";
-import { FaArrowRight } from "react-icons/fa";
+import { FaArrowRight, FaSpinner } from "react-icons/fa";
 import { getNearbyTruck, getFoodNewTrucks } from "@/app/database-actions";
 import { getLocation } from "../map/geo-utils";
 import { createToast } from "@/utils/toast";
@@ -25,9 +25,9 @@ export default function FoodTruckCardLanding(
   const [locationDenied, setLocationDenied] = useState<boolean>(false);
 
   const locationToast = createToast(
-    "Location permissions denied! This app relies heavily on geolocation. Please consider granting location access.",
+    "Location permissions denied! This app relies heavily on geolocation. Please consider granting location access. Refresh to grant access.",
     "error",
-    8000
+    10000
   );
 
   useEffect(() => {
@@ -66,7 +66,10 @@ export default function FoodTruckCardLanding(
       <div className="flex flex-col gap-4 p-3 bg-muted">
         {!locationDenied ? (
           loading ? (
-            <p>Loading nearby food trucks...</p>
+            <p className="flex items-center gap-2 h-full w-full">
+              Loading Nearby Food Trucks{" "}
+              <FaSpinner className="animate-[spin_2s_ease-in-out_infinite] text-primary" />
+            </p>
           ) : trucks?.length === 0 || !trucks ? (
             <p>No food trucks found in your area.</p>
           ) : (
@@ -97,7 +100,6 @@ export default function FoodTruckCardLanding(
                           <div className="relative w-1/2 pt-3 pb-3 pr-3">
                             <p className="text-sm m-1">{`${Math.floor(truck.nearest_dist_meters)} meters from you`}</p>
                           </div>
-                          {/* we need to fix the link here currently just the map */}
                           <div className="flex justify-center items-center text-background text-2xl ml-auto bg-primary w-16">
                             <FaArrowRight />
                           </div>
@@ -134,7 +136,6 @@ export default function FoodTruckCardLanding(
                           </h2>
                           <p>{truck.food_style}</p>
                         </div>
-                        {/* we need to fix the link here currently just the map */}
                         <div className="flex justify-center items-center text-background text-2xl ml-auto bg-primary w-16">
                           <FaArrowRight />
                         </div>

--- a/components/food-truck/food-truck-card-landing.tsx
+++ b/components/food-truck/food-truck-card-landing.tsx
@@ -4,8 +4,11 @@ import { Truck, Location } from "./../global-component-types";
 import Image from "next/image";
 import Link from "next/link";
 import { FaArrowRight } from "react-icons/fa";
-import { getNearbyTruck } from "@/app/database-actions";
+import { getNearbyTruck, getFoodNewTrucks } from "@/app/database-actions";
 import { getLocation } from "../map/geo-utils";
+import { createToast } from "@/utils/toast";
+import { ToastContainer } from "react-toastify";
+
 type FoodTruckCardProps = {
   // foodTruck: Truck;
 };
@@ -17,16 +20,19 @@ export default function FoodTruckCardLanding(
 ) {
   const [location, setLocation] = useState<Location | null>();
   const [trucks, setTrucks] = useState<any[]>();
+  const [newTrucks, setNewTrucks] = useState<any[] | null>();
   const [loading, setLoading] = useState(true);
   const [locationDenied, setLocationDenied] = useState<boolean>(false);
+
+  const locationToast = createToast(
+    "Location permissions denied! This app relies heavily on geolocation. Please consider granting location access.",
+    "error",
+    8000
+  );
 
   useEffect(() => {
     getLocation(setLocation, setLocationDenied);
   }, []);
-
-  useEffect(() => {
-    console.log("Location denied", locationDenied);
-  }, [locationDenied]);
 
   useEffect(() => {
     const fetchTruck = async () => {
@@ -44,58 +50,104 @@ export default function FoodTruckCardLanding(
     };
     fetchTruck();
   }, [location]);
-  return (
-    <div className="flex flex-col gap-4 p-3 bg-muted">
-      <h1 className="text-xl text-primary">
-        <strong>Nearby Food Trucks You Might Like</strong>
-      </h1>
 
-      {!locationDenied ? (
-        loading ? (
-          <p>Loading nearby food trucks...</p>
-        ) : trucks?.length === 0 || !trucks ? (
-          <p>No food trucks found in your area.</p>
+  useEffect(() => {
+    (async () => {
+      setNewTrucks(await getFoodNewTrucks());
+    })();
+
+    if (locationDenied && locationToast) {
+      locationToast();
+    }
+  }, [locationDenied]);
+
+  return (
+    <>
+      <div className="flex flex-col gap-4 p-3 bg-muted">
+        {!locationDenied ? (
+          loading ? (
+            <p>Loading nearby food trucks...</p>
+          ) : trucks?.length === 0 || !trucks ? (
+            <p>No food trucks found in your area.</p>
+          ) : (
+            <>
+              <h1 className="text-xl text-primary">
+                <strong>Nearby Food Trucks You Might Like</strong>
+              </h1>
+              {/* display nearby trucks */}
+              {trucks.map((truck) => {
+                return (
+                  <div key={truck.id}>
+                    <Link href={`/truck-profile/${truck.id}`}>
+                      <div className="rounded-xl bg-background overflow-clip shadow-md ring-1 ring-primary">
+                        <Image
+                          className="h-[200px] object-cover"
+                          src={truck.avatar}
+                          alt="Picture of a food truck"
+                          width={600}
+                          height={600}
+                        ></Image>
+                        <div className="flex flex-row">
+                          <div className="relative w-1/2 pt-3 pb-3 pl-3">
+                            <h2 className="text-lg font-semibold text-primary">
+                              {truck.name}
+                            </h2>
+                            <p>{truck.food_style}</p>
+                          </div>
+                          <div className="relative w-1/2 pt-3 pb-3 pr-3">
+                            <p className="text-sm m-1">{`${Math.floor(truck.nearest_dist_meters)} meters from you`}</p>
+                          </div>
+                          {/* we need to fix the link here currently just the map */}
+                          <div className="flex justify-center items-center text-background text-2xl ml-auto bg-primary w-16">
+                            <FaArrowRight />
+                          </div>
+                        </div>
+                      </div>
+                    </Link>
+                  </div>
+                );
+              })}
+            </>
+          )
         ) : (
-          trucks.map((truck) => {
-            return (
-              <div key={truck.id}>
-                <Link href={`/truck-profile/${truck.id}`}>
-                  <div className="rounded-xl bg-background overflow-clip shadow-md ring-1 ring-primary">
-                    <Image
-                      className="h-[200px] object-cover"
-                      src={truck.avatar}
-                      alt="Picture of a food truck"
-                      width={600}
-                      height={600}
-                    ></Image>
-                    <div className="flex flex-row">
-                      {/* <div className="p-3"> */}
-                      <div className="relative w-1/2 pt-3 pb-3 pl-3">
-                        <h2 className="text-lg font-semibold text-primary">
-                          {truck.name}
-                        </h2>
-                        <p>{truck.food_style}</p>
-                      </div>
-                      <div className="relative w-1/2 pt-3 pb-3 pr-3">
-                        <p className="text-sm m-1">{`${Math.floor(truck.nearest_dist_meters)} meters from you`}</p>
-                      </div>
-                      {/* we need to fix the link here currently just the map */}
-                      <div className="flex justify-center items-center text-background text-2xl ml-auto bg-primary w-16">
-                        <FaArrowRight />
+          <>
+            <h1 className="text-xl text-primary">
+              <strong>Recently Added Food Trucks You Might Like</strong>
+            </h1>
+            {/* display recently added trucks */}
+            {newTrucks?.map((truck) => {
+              return (
+                <div key={truck.id}>
+                  <Link href={`/truck-profile/${truck.id}`}>
+                    <div className="rounded-xl bg-background overflow-clip shadow-md ring-1 ring-primary">
+                      <Image
+                        className="h-[200px] object-cover"
+                        src={truck.avatar}
+                        alt="Picture of a food truck"
+                        width={600}
+                        height={600}
+                      ></Image>
+                      <div className="flex flex-row">
+                        <div className="relative w-1/2 pt-3 pb-3 pl-3">
+                          <h2 className="text-lg font-semibold text-primary">
+                            {truck.name}
+                          </h2>
+                          <p>{truck.food_style}</p>
+                        </div>
+                        {/* we need to fix the link here currently just the map */}
+                        <div className="flex justify-center items-center text-background text-2xl ml-auto bg-primary w-16">
+                          <FaArrowRight />
+                        </div>
                       </div>
                     </div>
-                  </div>
-                </Link>
-              </div>
-            );
-          })
-        )
-      ) : (
-        <p>
-          This web app relies heavily on geolocation. Please consider granting
-          access to your devices location
-        </p>
-      )}
-    </div>
+                  </Link>
+                </div>
+              );
+            })}
+          </>
+        )}
+      </div>
+      <ToastContainer />
+    </>
   );
 }

--- a/components/food-truck/food-truck-card-recent.tsx
+++ b/components/food-truck/food-truck-card-recent.tsx
@@ -1,0 +1,50 @@
+import Image from "next/image";
+import Link from "next/link";
+import React from "react";
+import { FaArrowRight } from "react-icons/fa";
+import { Truck } from "../global-component-types";
+
+type FoodTruckCardRecentProps = {
+  trucks: any[] | null | undefined;
+};
+
+export default function FoodTruckCardRecent({
+  trucks,
+}: FoodTruckCardRecentProps) {
+  return (
+    <>
+      <h1 className="text-xl text-primary">
+        <strong>Recently Added Food Trucks You Might Like</strong>
+      </h1>
+      {/* display recently added trucks */}
+      {trucks?.map((truck) => {
+        return (
+          <div key={truck.id}>
+            <Link href={`/truck-profile/${truck.id}`}>
+              <div className="rounded-xl bg-background overflow-clip shadow-md ring-1 ring-primary">
+                <Image
+                  className="h-[200px] object-cover"
+                  src={truck.avatar}
+                  alt="Picture of a food truck"
+                  width={600}
+                  height={600}
+                ></Image>
+                <div className="flex flex-row">
+                  <div className="relative w-1/2 pt-3 pb-3 pl-3">
+                    <h2 className="text-lg font-semibold text-primary">
+                      {truck.name}
+                    </h2>
+                    <p>{truck.food_style}</p>
+                  </div>
+                  <div className="flex justify-center items-center text-background text-2xl ml-auto bg-primary w-16">
+                    <FaArrowRight />
+                  </div>
+                </div>
+              </div>
+            </Link>
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/components/map/add-sighting.tsx
+++ b/components/map/add-sighting.tsx
@@ -37,6 +37,8 @@ export default function AddSighting({
   //   use this and effect cleanup to popup toast message
   const [success, setSuccess] = useState<boolean | null>(null);
 
+  const [locationDenied, setLocationDenied] = useState<boolean>(false);
+
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const searchTerm = event.target.value;
     setSearchItem(searchTerm);
@@ -48,7 +50,7 @@ export default function AddSighting({
   };
 
   useEffect(() => {
-    getLocation(setSightingLocation);
+    getLocation(setSightingLocation, setLocationDenied);
   }, []);
 
   useEffect(() => {

--- a/components/map/geo-utils.ts
+++ b/components/map/geo-utils.ts
@@ -49,7 +49,10 @@ export const clear = (markers: any[]) => {
   });
 };
 
-export const getLocation = (setLocation: Function) => {
+export const getLocation = (
+  setLocation: Function,
+  setLocationDenied: React.Dispatch<React.SetStateAction<boolean>>
+) => {
   if (navigator.geolocation) {
     navigator.geolocation.getCurrentPosition(
       (position) => {
@@ -57,8 +60,10 @@ export const getLocation = (setLocation: Function) => {
           lat: position.coords.latitude,
           lng: position.coords.longitude,
         });
+        setLocationDenied(false);
       },
       (error) => {
+        setLocationDenied(true);
         throw error;
       }
     );

--- a/components/map/geo-utils.ts
+++ b/components/map/geo-utils.ts
@@ -71,7 +71,10 @@ export const getLocation = (
 };
 
 // very similar to getLocation but will update when the users position changes
-export const trackLocation = (setLocation: Function) => {
+export const trackLocation = (
+  setLocation: Function,
+  setLocationDenied: React.Dispatch<React.SetStateAction<boolean>>
+) => {
   if (navigator.geolocation) {
     return navigator.geolocation.watchPosition(
       (position) => {
@@ -79,8 +82,12 @@ export const trackLocation = (setLocation: Function) => {
           lat: position.coords.latitude,
           lng: position.coords.longitude,
         });
+        setLocationDenied(false);
       },
-      (error) => console.error(error),
+      (error) => {
+        setLocationDenied(true);
+        throw error;
+      },
       { enableHighAccuracy: true }
     );
   }

--- a/components/map/map.tsx
+++ b/components/map/map.tsx
@@ -49,7 +49,7 @@ export default function Map() {
 
   // state varaibles
   const [user, setUser] = useState<UserMetadata | undefined>(undefined);
-
+  const [locationDenied, setLocationDenied] = useState<boolean>(false);
   const [map, setMap] = useState<google.maps.Map | null>(null);
   const [autoComplete, setAutoComplete] =
     useState<google.maps.places.Autocomplete | null>(null);
@@ -85,11 +85,18 @@ export default function Map() {
     message: string;
     type: string;
   } | null>(null);
+
   const { isLoaded } = useJsApiLoader({
     googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY as string,
     libraries: libs,
     version: "weekly",
   });
+
+  const locationToast = createToast(
+    "Location permissions denied! This app relies heavily on geolocation. Please consider refreshing to grant location access.",
+    "error",
+    10000
+  );
 
   // toggle display to add sighting
   const handleToggleAddSighting = () => {
@@ -181,13 +188,19 @@ export default function Map() {
 
     let id: any;
     try {
-      id = trackLocation(setLocation);
+      id = trackLocation(setLocation, setLocationDenied);
     } catch (error) {
       navigator.geolocation.clearWatch(id);
-      getLocation(setLocation);
+      getLocation(setLocation, setLocationDenied);
       // Toast error (currently is using static location)
     }
   }, []);
+
+  useEffect(() => {
+    if (locationDenied && locationToast) {
+      locationToast();
+    }
+  }, [locationDenied]);
 
   useEffect(() => {
     // updates the users marker when position changes
@@ -312,115 +325,122 @@ export default function Map() {
 
   return (
     <>
-      {isLoaded && location ? (
-        <div className="flex flex-col h-full">
-          {/* MAP */}
-          <div id="map" ref={mapRef} className="grow"></div>
-          {/* MAP */}
+      {!locationDenied ? (
+        isLoaded && location ? (
+          <div className="flex flex-col h-full">
+            {/* MAP */}
+            <div id="map" ref={mapRef} className="grow"></div>
+            {/* MAP */}
 
-          <div className="absolute w-full flex flex-row justify-center items-center">
-            <div className="relative flex p-2 gap-1 w-full">
-              <div className="flex gap-2 w-full justify-center h-10 items-center">
-                <button
-                  className="h-8 w-8 bg-primary flex items-center justify-center rounded-xl  "
-                  onClick={async () => {
-                    if (!displaySightingsMarker) {
-                      fetchSighting(
-                        location,
-                        map as google.maps.Map,
-                        setSighting,
-                        setSelectedSighting
-                      );
-                      setDisplaySightingsMarker(true);
-                    }
-                    if (displaySightingsMarker && sightings) {
-                      clear(sightings);
-                      setSelectedSighting(null);
-                      setDisplaySightingsMarker(false);
-                    }
-                  }}
-                >
-                  <FaMapMarkerAlt className="fill-white" />
-                </button>
-                <Filter buttonActions={buttonActions} />
+            <div className="absolute w-full flex flex-row justify-center items-center">
+              <div className="relative flex p-2 gap-1 w-full">
+                <div className="flex gap-2 w-full justify-center h-10 items-center">
+                  <button
+                    className="h-8 w-8 bg-primary flex items-center justify-center rounded-xl  "
+                    onClick={async () => {
+                      if (!displaySightingsMarker) {
+                        fetchSighting(
+                          location,
+                          map as google.maps.Map,
+                          setSighting,
+                          setSelectedSighting
+                        );
+                        setDisplaySightingsMarker(true);
+                      }
+                      if (displaySightingsMarker && sightings) {
+                        clear(sightings);
+                        setSelectedSighting(null);
+                        setDisplaySightingsMarker(false);
+                      }
+                    }}
+                  >
+                    <FaMapMarkerAlt className="fill-white" />
+                  </button>
+                  <Filter buttonActions={buttonActions} />
 
-                {/* display sighitngs */}
-              </div>
-              <Input
-                className="h-9 w-full ml-auto"
-                type="text"
-                ref={placeAutoCompleteRef}
-                placeholder="Search by location"
-              />
-            </div>
-
-            {selectedSighting && (
-              <div className="absolute flex flex-col h-fit w-fit justify-center items-center top-16 bg-white rounded-xl border border-gray-300">
-                <SightingConfirmCard
-                  user={user}
-                  setToastMessage={setToastMessage}
-                  sighting={selectedSighting}
-                  setSelectedSighting={setSelectedSighting}
+                  {/* display sighitngs */}
+                </div>
+                <Input
+                  className="h-9 w-full ml-auto"
+                  type="text"
+                  ref={placeAutoCompleteRef}
+                  placeholder="Search by location"
                 />
               </div>
-            )}
 
-            {isAddingActive && geocoder && (
-              <div className="absolute flex flex-col h-90 w-96 justify-center items-center top-16 ">
-                <div className="relative w-fit h-fit items-center">
-                  {isDisplayedAddSighting && (
-                    <div className="relative w-80 h-fit bg-white p-2  border border-gray-300 rounded-xl ">
-                      <AddSighting
-                        setToastMessage={setToastMessage}
-                        handleToggleAddSighting={handleToggleAddSighting}
-                        handleToggleAddTruck={handleToggleAddTruck}
-                        geocoder={geocoder}
-                      />
-                    </div>
-                  )}
+              {selectedSighting && (
+                <div className="absolute flex flex-col h-fit w-fit justify-center items-center top-16 bg-white rounded-xl border border-gray-300">
+                  <SightingConfirmCard
+                    user={user}
+                    setToastMessage={setToastMessage}
+                    sighting={selectedSighting}
+                    setSelectedSighting={setSelectedSighting}
+                  />
                 </div>
+              )}
 
-                <div className="relative w-fit h-fit items-center">
-                  {isDisplayedAddTruck && (
-                    <div className="relative w-fit h-fit bg-white p-2  border border-gray-300 rounded-xl ">
-                      <AddNewFoodTruckForm
-                        setToastMessage={setToastMessage}
-                        handleToggleAddTruck={handleToggleAddTruck}
-                        handleToggleAddSighting={handleToggleAddSighting}
-                        location={location}
-                        geocoder={geocoder}
-                      />
-                    </div>
-                  )}
+              {isAddingActive && geocoder && (
+                <div className="absolute flex flex-col h-90 w-96 justify-center items-center top-16 ">
+                  <div className="relative w-fit h-fit items-center">
+                    {isDisplayedAddSighting && (
+                      <div className="relative w-80 h-fit bg-white p-2  border border-gray-300 rounded-xl ">
+                        <AddSighting
+                          setToastMessage={setToastMessage}
+                          handleToggleAddSighting={handleToggleAddSighting}
+                          handleToggleAddTruck={handleToggleAddTruck}
+                          geocoder={geocoder}
+                        />
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="relative w-fit h-fit items-center">
+                    {isDisplayedAddTruck && (
+                      <div className="relative w-fit h-fit bg-white p-2  border border-gray-300 rounded-xl ">
+                        <AddNewFoodTruckForm
+                          setToastMessage={setToastMessage}
+                          handleToggleAddTruck={handleToggleAddTruck}
+                          handleToggleAddSighting={handleToggleAddSighting}
+                          location={location}
+                          geocoder={geocoder}
+                        />
+                      </div>
+                    )}
+                  </div>
                 </div>
-              </div>
-            )}
-          </div>
+              )}
+            </div>
 
-          <ToastContainer></ToastContainer>
-          {/* add new button:  */}
-          <div
-            className="absolute bottom-0 right-0 m-3 inline-flex items-center justify-center bg-primary rounded-full w-14 h-14"
-            onClick={() => {
-              if (!user) {
-                return router.push("/sign-in?error=Not signed in");
-              }
-              handleToggleAddButton();
-            }}
-          >
-            <FaPlus
-              className="focus:outline-none focus:ring-4 focus:shadow font-sans rounded-full  "
-              color="white"
-              fontSize={16}
-            />
+            <ToastContainer></ToastContainer>
+            {/* add new button:  */}
+            <div
+              className="absolute bottom-0 right-0 m-3 inline-flex items-center justify-center bg-primary rounded-full w-14 h-14"
+              onClick={() => {
+                if (!user) {
+                  return router.push("/sign-in?error=Not signed in");
+                }
+                handleToggleAddButton();
+              }}
+            >
+              <FaPlus
+                className="focus:outline-none focus:ring-4 focus:shadow font-sans rounded-full  "
+                color="white"
+                fontSize={16}
+              />
+            </div>
           </div>
-        </div>
+        ) : (
+          <div className="flex justify-center items-center gap-2 text-lg mt-2">
+            Loading map{" "}
+            <FaSpinner className="animate-[spin_2s_ease-in-out_infinite] text-primary" />
+          </div>
+        )
       ) : (
         <div className="flex justify-center items-center gap-2 text-lg mt-2">
-          Loading map{" "}
-          <FaSpinner className="animate-[spin_2s_ease-in-out_infinite] text-primary" />
+          Error loading map. Please check permissions.
         </div>
       )}
+      <ToastContainer />
     </>
   );
 }

--- a/components/map/map.tsx
+++ b/components/map/map.tsx
@@ -373,6 +373,9 @@ export default function Map() {
               {selectedSighting && (
                 <div className="absolute flex flex-col h-fit w-fit justify-center items-center top-16 bg-white rounded-xl border border-gray-300">
                   <SightingConfirmCard
+                    location={location}
+                    map={map as google.maps.Map}
+                    setSighting={setSighting}
                     user={user}
                     setToastMessage={setToastMessage}
                     sighting={selectedSighting}


### PR DESCRIPTION
Closes #109 

Added error handling for when location permissions are denied.

1.  On the landing page if location permissions are denied, instead of displaying near by trucks, recently added trucks are displayed. An error toast is also displayed informing them that we rely heavily on geolocation and encourage them to grant access.
2.  Instead of displaying "No nearby trucks" when no nearby trucks are found, display recently added trucks.
3. On the map page display a message saying there was an error loading the map as well as the same toast as on the landing page.

![image](https://github.com/user-attachments/assets/6312b41e-7a02-43f7-9d72-3401d0d57aec)
![image](https://github.com/user-attachments/assets/49ba70ff-f142-4ad5-a6bd-c9845fee3488)
