### PR TITLE
Feat/sighting card UI

### DIFF
--- a/components/food-truck/add-new-food-truck-form.tsx
+++ b/components/food-truck/add-new-food-truck-form.tsx
@@ -64,6 +64,7 @@ export default function AddNewFoodTruckForm({
             Profile Picture
           </Label>
           <Input
+            required
             type="file"
             name="truck-profile-picture"
             onChange={(e) => {

--- a/components/food-truck/add-or-edit-reviews.tsx
+++ b/components/food-truck/add-or-edit-reviews.tsx
@@ -66,6 +66,7 @@ export default function AddReviewFoodTruckForm({
             Image
           </Label>
           <Input
+            required
             type="file"
             name="review-picture"
             onChange={(e) => {

--- a/components/map/map.tsx
+++ b/components/map/map.tsx
@@ -114,7 +114,7 @@ export default function Map() {
   // maybe pass all of those stuff with setters to filter component when cleaning up the map component
   // refresh sighting confirm number realtime: pass a refresh state hook, trigger get sighting by id if confirmed, to increment confirm number immediately
   const buttonActions = {
-    searchInGoogle: () => {
+    staticTrucks: () => {
       if (!displayPlacesMarker && location) {
         searchFoodTruck(google, map as google.maps.Map, setPlaces, location);
         setDisplayPlacesMarker(true);
@@ -124,7 +124,7 @@ export default function Map() {
         setDisplayPlacesMarker(false);
       }
     },
-    sightingActiveInLastWeek: async () => {
+    activeInLastWeek: async () => {
       if (!displaySightingsMarker) {
         const data = await getSightingActiveInLastWeek();
         if (data instanceof PostgrestError) {
@@ -145,7 +145,7 @@ export default function Map() {
         setDisplaySightingsMarker(false);
       }
     },
-    popularSightings: async () => {
+    popular: async () => {
       if (!displaySightingsMarker) {
         const data = await getSightingsOrderedByLastActiveCountConfirm();
         if (data instanceof PostgrestError) {
@@ -357,6 +357,9 @@ export default function Map() {
             {selectedSighting && (
               <div className="absolute flex flex-col h-fit w-fit justify-center items-center top-16 bg-white rounded-xl border border-gray-300 overflow-clip">
                 <SightingConfirmCard
+                  location={location}
+                  map={map as google.maps.Map}
+                  setSighting={setSighting}
                   user={user}
                   setToastMessage={setToastMessage}
                   sighting={selectedSighting}

--- a/components/map/map.tsx
+++ b/components/map/map.tsx
@@ -355,7 +355,7 @@ export default function Map() {
             </div>
 
             {selectedSighting && (
-              <div className="absolute flex flex-col h-fit w-fit justify-center items-center top-16 bg-white rounded-xl border border-gray-300">
+              <div className="absolute flex flex-col h-fit w-fit justify-center items-center top-16 bg-white rounded-xl border border-gray-300 overflow-clip">
                 <SightingConfirmCard
                   user={user}
                   setToastMessage={setToastMessage}

--- a/components/map/sighting-confirm-card.tsx
+++ b/components/map/sighting-confirm-card.tsx
@@ -39,18 +39,31 @@ export default function SightingConfirmCard({
   }, []);
 
   return (
-    <div className="h-64 w-80 justify-center items-center flex flex-col">
-      <div className="w-full absolute h-9 top-0 flex flex-row-reverse ">
-        <button
-          className="relative right-1 bg-primary top-1 p-2 text-primary-foreground rounded-xl flex-none w-9 h-9 flex justify-center items-center"
-          onClick={() => {
-            setSelectedSighting(null);
-          }}
-        >
-          <IoMdClose />
-        </button>
+    <div className="relative  w-80 flex flex-col">
+      <button
+        className="absolute right-1 bg-primary top-1 p-2 text-primary-foreground rounded-xl flex-none w-9 h-9 flex justify-center items-center"
+        onClick={() => {
+          setSelectedSighting(null);
+        }}
+      >
+        <IoMdClose />
+      </button>
+      <div className="absolute left-2 top-2 flex items-center text-primary text-xl font-bold ">
+        <p className="text-center mr-1">{sighting.confirmation_count}</p>
+        <GiConfirmed size={22} />
       </div>
-      <div className=" w-64 justify-center items-center bg-primary mt-1 mb-1  rounded-xl">
+
+      <div className="flex">
+        <img className="object-cover w-32 " src={truck?.avatar} alt="" />
+
+        <div className="ml-2 flex flex-col">
+          <p>{truck?.name}</p>
+          <p>{truck?.food_style}</p>
+
+          {sighting.address_formatted && <p>{sighting.address_formatted}</p>}
+        </div>
+      </div>
+      <div className=" w-64 justify-center items-center bg-primary mt-1 mb-1 rounded-xl">
         <Link
           className="justify-center items-center h-full w-full "
           onClick={() => {
@@ -86,20 +99,6 @@ export default function SightingConfirmCard({
             Confirm Sighting
           </p>
         </button>
-      </div>
-      <div className="flex flex-row">
-        <div className="flex h-24 w-24 overflow-hidden   object-cover mt-2">
-          <img className="object-cover h-36 w-48 " src={truck?.avatar} alt="" />
-        </div>
-        <div className="ml-2 flex flex-col justify-center justify-self-center items-center">
-          <p>{truck?.name}</p>
-          <p>{truck?.food_style}</p>
-          <div className="flex flex-row justify-center justify-self-center items-center">
-            <p className="text-center mr-1">{sighting.confirmation_count}</p>
-            <GiConfirmed />
-          </div>
-          {sighting.address_formatted && <p>{sighting.address_formatted}</p>}
-        </div>
       </div>
     </div>
   );

--- a/components/map/sighting-confirm-card.tsx
+++ b/components/map/sighting-confirm-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { Sighting, Truck } from "../global-component-types";
+import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import { Truck } from "../global-component-types";
 import {
   addSightingConfirmation,
   getFoodTruckDataById,
@@ -11,7 +11,12 @@ import { UserMetadata } from "@supabase/supabase-js";
 import { useRouter } from "next/navigation";
 import { GiConfirmed } from "react-icons/gi";
 import { IoMdClose } from "react-icons/io";
+import { fetchSighting } from "./geo-utils";
 type SightingConfirmCardProps = {
+  location: any;
+  map: google.maps.Map;
+  setSighting: Dispatch<SetStateAction<any[] | undefined>>;
+
   setToastMessage: (params: { message: string; type: string }) => void;
   sighting: any;
   setSelectedSighting: Function;
@@ -19,6 +24,9 @@ type SightingConfirmCardProps = {
 };
 
 export default function SightingConfirmCard({
+  location,
+  map,
+  setSighting,
   setToastMessage,
   sighting,
   setSelectedSighting,
@@ -48,57 +56,77 @@ export default function SightingConfirmCard({
       >
         <IoMdClose />
       </button>
-      <div className="absolute left-2 top-2 flex items-center text-primary text-xl font-bold ">
-        <p className="text-center mr-1">{sighting.confirmation_count}</p>
+
+      <div className="absolute left-2 top-1 flex items-center text-primary drop-shadow-lg text-xl font-bold ">
         <GiConfirmed size={22} />
+        <p className="text-center ml-1">{sighting.confirmation_count}</p>
       </div>
 
-      <div className="flex">
+      <div className="flex bg-muted">
         <img className="object-cover w-32 " src={truck?.avatar} alt="" />
-
-        <div className="ml-2 flex flex-col">
-          <p>{truck?.name}</p>
-          <p>{truck?.food_style}</p>
-
-          {sighting.address_formatted && <p>{sighting.address_formatted}</p>}
+        <div className="ml-2 flex flex-col justify-center">
+          <p className="text-lg text-primary font-semibold truncate w-[140px]">
+            {truck?.name}
+          </p>
+          <p className="-mt-1 text-sm">{truck?.food_style}</p>
+          {sighting.address_formatted && (
+            <p className="text-sm mt-2">{sighting.address_formatted}</p>
+          )}
         </div>
       </div>
-      <div className=" w-64 justify-center items-center bg-primary mt-1 mb-1 rounded-xl">
-        <Link
-          className="justify-center items-center h-full w-full "
-          onClick={() => {
-            setSelectedSighting(null);
-          }}
-          href={`/truck-profile/${truck?.id}`}
-        >
-          <p className="justify-center items-center text-center">Go TO Truck</p>
-        </Link>
-      </div>
-      <div className="w-64 bg-primary mt-1 mb-1 ml-3 mr-3 rounded-xl">
-        <button
-          className="h-full w-full"
-          onClick={async () => {
-            if (!user) {
-              return router.push("/sign-in?error=Not signed in");
-            }
-            const data = await addSightingConfirmation(
-              sighting.id,
-              sighting.food_truck_id
-            );
-            if (data) {
-              // toast
-              setToastMessage({
-                message: "successfully confirmed",
-                type: "success",
-              });
-            }
-            setSelectedSighting(null);
-          }}
-        >
-          <p className="justify-center items-center text-center">
-            Confirm Sighting
-          </p>
-        </button>
+
+      <div className="flex flex-col items-center p-2">
+        <div className="w-64 bg-primary my-1 mx-3 rounded-xl text-background py-[0.1rem]">
+          <Link
+            className="justify-center items-center h-full w-full "
+            onClick={() => {
+              setSelectedSighting(null);
+            }}
+            href={`/truck-profile/${truck?.id}`}
+          >
+            <p className="justify-center items-center text-center">
+              Go to Truck
+            </p>
+          </Link>
+        </div>
+
+        <div className="w-64 bg-primary mt-1 mb-1 ml-3 mr-3 rounded-xl text-background py-[0.1rem]">
+          <button
+            className="h-full w-full"
+            onClick={async () => {
+              if (!user) {
+                return router.push("/sign-in?error=Not signed in");
+              }
+              const data = await addSightingConfirmation(
+                sighting.id,
+                sighting.food_truck_id
+              );
+
+              // This is sort of working but it seems to cause issues with the filtering <----- Yizhen
+              // updates the sightings so confirmations show without a refresh
+              // fetchSighting(
+              //   location,
+              //   map as google.maps.Map,
+              //   setSighting,
+              //   setSelectedSighting
+              // );
+
+              if (data) {
+                // toast
+                setToastMessage({
+                  message: "successfully confirmed",
+                  type: "success",
+                });
+              }
+
+              setSelectedSighting(null);
+            }}
+          >
+            <p className="justify-center items-center text-center">
+              Confirm Sighting
+            </p>
+          </button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #108 

Improve the UI for the sighting confirm modal. 

I tried to make confirmations update without refreshing but I was getting some strange behavior.
After I confirm a sighting it updates but the filters stop working. If i refresh the page the filters work but then break again when I confirm another sighting.

**Problem code** - in sighting-confirm-card.tsx
![image](https://github.com/user-attachments/assets/df9e4616-de8b-420e-b112-5d36900fb3b0)



![image](https://github.com/user-attachments/assets/f94d7eea-8960-4905-94c0-9b2c96d6564f)

**Fixes** - Made it required to add a photo when adding a food truck