### PR TITLE
feat: improve sidebar to display full height and add animation

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -6,7 +6,7 @@ import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 
 export const signUpAction = async (formData: FormData) => {
-  const display_name = formData.get("display_name")?.toString()
+  const display_name = formData.get("display_name")?.toString();
   const email = formData.get("email")?.toString();
   const password = formData.get("password")?.toString();
   const supabase = await createClient();
@@ -16,7 +16,7 @@ export const signUpAction = async (formData: FormData) => {
     return encodedRedirect(
       "error",
       "/sign-up",
-      "Email and password are required",
+      "Email and password are required"
     );
   }
 
@@ -33,11 +33,14 @@ export const signUpAction = async (formData: FormData) => {
     console.error(error.code + " " + error.message);
     return encodedRedirect("error", "/sign-up", error.message);
   } else {
-    return encodedRedirect(
-      "success",
-      "/sign-up",
-      "Thanks for signing up! Please check your email for a verification link.",
-    );
+    // for no confirmation
+    redirect("/");
+    // for email authentication
+    // return encodedRedirect(
+    //   "success",
+    //   "/sign-up",
+    //   "Thanks for signing up! Please check your email for a verification link."
+    // );
   }
 };
 
@@ -77,7 +80,7 @@ export const forgotPasswordAction = async (formData: FormData) => {
     return encodedRedirect(
       "error",
       "/forgot-password",
-      "Could not reset password",
+      "Could not reset password"
     );
   }
 
@@ -88,7 +91,7 @@ export const forgotPasswordAction = async (formData: FormData) => {
   return encodedRedirect(
     "success",
     "/forgot-password",
-    "Check your email for a link to reset your password.",
+    "Check your email for a link to reset your password."
   );
 };
 
@@ -102,7 +105,7 @@ export const resetPasswordAction = async (formData: FormData) => {
     encodedRedirect(
       "error",
       "/protected/reset-password",
-      "Password and confirm password are required",
+      "Password and confirm password are required"
     );
   }
 
@@ -110,7 +113,7 @@ export const resetPasswordAction = async (formData: FormData) => {
     encodedRedirect(
       "error",
       "/protected/reset-password",
-      "Passwords do not match",
+      "Passwords do not match"
     );
   }
 
@@ -122,7 +125,7 @@ export const resetPasswordAction = async (formData: FormData) => {
     encodedRedirect(
       "error",
       "/protected/reset-password",
-      "Password update failed",
+      "Password update failed"
     );
   }
 

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -25,6 +25,12 @@ export default function Header({ user }: HeaderProps) {
 
   return (
     <>
+      <button
+        className="fixed top-3 right-2 z-30 text-gray-700 text-2xl border-2 border-primary bg-muted rounded-xl text-primary w-10 h-10 mr-[3px] flex justify-center items-center"
+        onClick={handleToggle}
+      >
+        {!isDisplayed ? <LuMenu /> : <MdClose />}
+      </button>
       <header className="fixed top-0 left-0 z-10 bg-background w-full flex shrink-0 justify-between items-center h-16 px-2 drop-shadow-sm ">
         {/* displays the logo */}
         <Link href="/">
@@ -37,12 +43,6 @@ export default function Header({ user }: HeaderProps) {
           ></Image>
         </Link>
         {/* menu button */}
-        <button
-          className="text-gray-700 text-2xl border-2 border-primary bg-muted rounded-xl text-primary w-10 h-10 mr-[3px] flex justify-center items-center"
-          onClick={handleToggle}
-        >
-          {!isDisplayed ? <LuMenu /> : <MdClose />}
-        </button>
       </header>
       {/* displays a different sidebar depending on login satus */}
       {user ? (

--- a/components/logout-button.tsx
+++ b/components/logout-button.tsx
@@ -13,10 +13,10 @@ export default function LogoutButton({ handleToggle }: LogoutButtonProps) {
         signOutAction();
         handleToggle();
       }}
-      className="flex flex-col justify-center font-semibold items-center text-foreground w-16 py-[6px] mt-3 text-sm"
+      className="flex font-semibold items-center w-40 h-12 p-3 mt-3"
     >
-      <GrLogout className="size-6 " />
-      <p>Logout</p>
+      <GrLogout size={26} />
+      <p className="ml-2">Logout</p>
     </button>
   );
 }

--- a/components/nav-button-mobile.tsx
+++ b/components/nav-button-mobile.tsx
@@ -23,28 +23,28 @@ export default function NavButtonMobile({
         <Link onClick={handleToggle} href={NavButton.href}>
           <div
             className={clsx(
-              "flex flex-col justify-center font-semibold items-center w-16 py-[6px] mt-3 text-sm",
+              "flex font-semibold items-center w-40 h-12 p-3 mt-3",
               {
                 "bg-primary text-background": pathname === NavButton.href,
               }
             )}
           >
-            <Icon className="size-6 " />
-            <p>{NavButton.text}</p>
+            <Icon size={26} />
+            <p className="ml-2">{NavButton.text}</p>
           </div>
         </Link>
       ) : (
         <a onClick={handleToggle} href={NavButton.href}>
           <div
             className={clsx(
-              "flex flex-col justify-center font-semibold items-center w-16 py-[6px] mt-3 text-sm",
+              "flex font-semibold items-center w-40 h-12 p-3 mt-3",
               {
                 "bg-primary text-background": pathname === NavButton.href,
               }
             )}
           >
-            <Icon className="size-6 " />
-            <p>{NavButton.text}</p>
+            <Icon size={26} />
+            <p className="ml-2">{NavButton.text}</p>
           </div>
         </a>
       )}

--- a/components/sidebar-mobile.tsx
+++ b/components/sidebar-mobile.tsx
@@ -18,21 +18,21 @@ export default function SidebarMobile({
   user,
 }: SidebarMobileProps) {
   return (
-    <div
-      className={clsx("fixed top-16 right-0 z-20 flex w-full h-screen", {
-        hidden: !isDisplayed,
-      })}
-    >
-      {/* this is temporary div to handle closing the menu when clicking outide
-      we should research a better way to do this as it breaks the animations */}
+    <>
+      {/* this is the gray area to the left of the sidebar */}
       <div
         onClick={handleToggle}
-        className={clsx("grow", { hidden: !isDisplayed })}
+        className={clsx(
+          "fixed top-0  w-full h-full bg-black bg-opacity-50 z-20",
+          {
+            hidden: !isDisplayed,
+          }
+        )}
       ></div>
       <div
         className={clsx(
-          "fixed top-16 right-0 translate-x-0 flex flex-col border-l-[1.5px] border-primary w-16 h-full  bg-muted transition-transform duration-300",
-          { "translate-x-16": !isDisplayed }
+          "fixed top-0 right-0 translate-x-0 flex flex-col border-l-[1.5px] border-primary w-40 h-full pt-16 bg-muted transition-transform duration-300 z-20",
+          { "translate-x-40": !isDisplayed }
         )}
       >
         {/* creates a button for each button passed to the component */}
@@ -46,6 +46,6 @@ export default function SidebarMobile({
         {/* displays logout button if a user is logged in */}
         {user ? <LogoutButton handleToggle={handleToggle} /> : null}
       </div>
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
Closes #127 
Closes #129 
Closes #118

Changed the side navigation to be full height, increased the width and formatted the buttons. I greyed out the area to the left of the side navigation to indicate you can't interact with the content below. I also added an animation to slide out the navigation.

**_I made a slight change to the sign up process which redirects the user to the homepage when they register, this is because we disabled email authentication_**

![image](https://github.com/user-attachments/assets/3dcb6d25-2520-4bc5-a845-b0a93430059b)
