### PR TITLE
Chore/redo styling landing

### DIFF
--- a/app/database-actions.ts
+++ b/app/database-actions.ts
@@ -91,12 +91,12 @@ export const getFoodTruckData = async () => {
 };
 
 // gets information about 10 most recently added trucks
-export const getFoodNewTrucks = async () => {
+export const getNewFoodTrucks = async () => {
   const supabase = await createClient();
   const { data, error } = await supabase
     .from("food_truck_profiles")
     .select()
-    .order("id", { ascending: true })
+    .order("id", { ascending: false })
     .limit(10); // orders alphabetically
 
   if (error) console.error("Error fetching all food truck data", error);

--- a/components/food-truck/food-truck-card-landing.tsx
+++ b/components/food-truck/food-truck-card-landing.tsx
@@ -6,13 +6,13 @@ import Link from "next/link";
 import { FaArrowRight, FaSpinner, FaMapMarkerAlt } from "react-icons/fa";
 import {
   getNearbyTruckFullInfo,
-  getFoodNewTrucks,
+  getNewFoodTrucks,
 } from "@/app/database-actions";
 import { getLocation } from "../map/geo-utils";
 import { createToast } from "@/utils/toast";
 import { ToastContainer } from "react-toastify";
 import FoodTruckCardRecent from "./food-truck-card-recent";
-import { montserrat, ranchers } from "../fonts";
+import { montserrat } from "../fonts";
 
 type FoodTruckCardProps = {
   // foodTruck: Truck;
@@ -60,7 +60,7 @@ export default function FoodTruckCardLanding(
 
   useEffect(() => {
     (async () => {
-      setNewTrucks(await getFoodNewTrucks());
+      setNewTrucks(await getNewFoodTrucks());
     })();
 
     if (locationDenied && locationToast) {
@@ -100,13 +100,13 @@ export default function FoodTruckCardLanding(
                           height={600}
                         ></Image>
                         <div className="flex flex-row">
-                          <div className="relative w-1/2 pt-3 pb-3 pl-3">
-                            <h2 className="text-lg font-semibold text-primary">
+                          <div className="px-3 py-2 truncate ">
+                            <h2 className="text-xl font-semibold truncate">
                               {truck.truck_name}
                             </h2>
-                            <p>{truck.truck_food_style}</p>
-                          </div>
-                          <div className="relative w-1/2 pt-3 pb-3 pr-3">
+                            <p className="-mt-1 text-sm text-gray-500">
+                              {truck.truck_food_style}
+                            </p>
                             {Math.floor(truck.nearest_dist_meters) < 1000 ? (
                               Math.floor(truck.nearest_dist_meters) <= 5 ? (
                                 <span className="flex gap-1 items-center mt-1">

--- a/components/food-truck/food-truck-card-recent.tsx
+++ b/components/food-truck/food-truck-card-recent.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import React from "react";
-import { FaArrowRight, FaMapMarkerAlt } from "react-icons/fa";
+import { FaArrowRight } from "react-icons/fa";
 import { Truck } from "../global-component-types";
 import { montserrat } from "../fonts";
 
@@ -37,9 +37,11 @@ export default function FoodTruckCardRecent({
                     <h2 className="text-xl font-semibold truncate w-full">
                       {truck.name}
                     </h2>
-                    <p className="-mt-1 text-sm">{truck.food_style}</p>
+                    <p className="-mt-1 text-sm text-gray-500">
+                      {truck.food_style}
+                    </p>
                   </div>
-                  <div className="flex justify-center items-center text-background text-2xl ml-auto bg-primary w-16 min-h-16">
+                  <div className="flex justify-center items-center text-background text-2xl ml-auto bg-primary w-16 min-w-16 min-h-16">
                     <FaArrowRight />
                   </div>
                 </div>

--- a/components/food-truck/sighting-card.tsx
+++ b/components/food-truck/sighting-card.tsx
@@ -33,6 +33,7 @@ export default function SightingCard({ sightingData }: SightingCardProps) {
     setLocalTime(
       `${year}-${month}-${day} ${dayOfWeek} ${hours}:${minutes}:${seconds}`
     );
+    console.log("TIME", sightingData.last_active_time);
   }, []);
 
   return (
@@ -40,28 +41,26 @@ export default function SightingCard({ sightingData }: SightingCardProps) {
       <div className="flex rounded-xl bg-background overflow-clip shadow-md ring-1 ring-primary">
         <div className="grow overflow-hidden px-2 py-1">
           {sightingData ? (
-            <div className="flex flex-row ">
-              <div className="flex flex-col w-80">
+            <div className="flex flex-row items-center px-2 h-16">
+              <div className="flex flex-col truncate grow">
                 {sightingData.address_formatted ? (
-                  <p className="truncate overflow-auto mb-1">
+                  <p className="truncate overflow-auto mb-1 font-semibold">
                     {sightingData.address_formatted}
                   </p>
                 ) : (
-                  <p className="truncate">{`lat: ${sightingData.lat}, lng: ${sightingData.lng}`}</p>
+                  <p className="truncate font-semibold">{`lat: ${sightingData.lat}, lng: ${sightingData.lng}`}</p>
                 )}
-                {pathname === "/user-profile" ? (
-                  <p>{`Created at: ${sightingData.created_at}`}</p>
-                ) : (
-                  <p>{`Last sighted at: ${localTime}`}</p>
-                )}
-              </div>
 
-              <div className="flex items-center justify-center w-full">
+                <p>
+                  Last seen: {dayjs(sightingData.last_active_time).fromNow()}
+                </p>
+              </div>
+              <div className="flex items-center justify-center ml-2">
                 {/* show how many  confirmation the sighting has, may need to change icon if it's confusing */}
-                <p className="text-center mr-1">
+                <GiConfirmed size={22} className="text-primary" />
+                <p className="text-center ml-1">
                   {sightingData.confirmation_count}
                 </p>
-                <GiConfirmed></GiConfirmed>
               </div>
             </div>
           ) : (
@@ -71,14 +70,6 @@ export default function SightingCard({ sightingData }: SightingCardProps) {
             </p>
           )}
         </div>
-        {pathname === "/user-profile" && (
-          <Link
-            href={`/truck-profile/${sightingData.food_truck_id}`}
-            className=" flex justify-center items-center text-background text-2xl bg-primary w-20"
-          >
-            <FaArrowRight />
-          </Link>
-        )}
       </div>
     </Link>
   );

--- a/components/food-truck/sighting-card.tsx
+++ b/components/food-truck/sighting-card.tsx
@@ -5,14 +5,16 @@ import Link from "next/link";
 import { GiConfirmed } from "react-icons/gi";
 import { FaSpinner } from "react-icons/fa";
 import { FaArrowRight } from "react-icons/fa";
-
 import { usePathname } from "next/navigation";
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
 
 type SightingCardProps = {
   sightingData: any;
 };
 
 export default function SightingCard({ sightingData }: SightingCardProps) {
+  dayjs.extend(relativeTime);
   const pathname = usePathname();
   const [localTime, setLocalTime] = useState<string>();
 
@@ -34,11 +36,11 @@ export default function SightingCard({ sightingData }: SightingCardProps) {
   }, []);
 
   return (
-    <div className="flex rounded-xl bg-background overflow-clip shadow-md ring-1 ring-primary">
-      <div className="grow overflow-hidden px-2 py-1">
-        {sightingData ? (
-          <div className="flex flex-row ">
-            <Link href={`/truck-map?sighting-id=${sightingData.id}`}>
+    <Link href={`/truck-map?sighting-id=${sightingData.id}`}>
+      <div className="flex rounded-xl bg-background overflow-clip shadow-md ring-1 ring-primary">
+        <div className="grow overflow-hidden px-2 py-1">
+          {sightingData ? (
+            <div className="flex flex-row ">
               <div className="flex flex-col w-80">
                 {sightingData.address_formatted ? (
                   <p className="truncate overflow-auto mb-1">
@@ -53,30 +55,31 @@ export default function SightingCard({ sightingData }: SightingCardProps) {
                   <p>{`Last sighted at: ${localTime}`}</p>
                 )}
               </div>
-            </Link>
-            <div className="flex items-center justify-center w-full">
-              {/* show how many  confirmation the sighting has, may need to change icon if it's confusing */}
-              <p className="text-center mr-1">
-                {sightingData.confirmation_count}
-              </p>
-              <GiConfirmed></GiConfirmed>
+
+              <div className="flex items-center justify-center w-full">
+                {/* show how many  confirmation the sighting has, may need to change icon if it's confusing */}
+                <p className="text-center mr-1">
+                  {sightingData.confirmation_count}
+                </p>
+                <GiConfirmed></GiConfirmed>
+              </div>
             </div>
-          </div>
-        ) : (
-          <p className="flex items-center gap-2 h-full w-full">
-            Loading Sighting{" "}
-            <FaSpinner className="animate-[spin_2s_ease-in-out_infinite] text-primary" />
-          </p>
+          ) : (
+            <p className="flex items-center gap-2 h-full w-full">
+              Loading Sighting{" "}
+              <FaSpinner className="animate-[spin_2s_ease-in-out_infinite] text-primary" />
+            </p>
+          )}
+        </div>
+        {pathname === "/user-profile" && (
+          <Link
+            href={`/truck-profile/${sightingData.food_truck_id}`}
+            className=" flex justify-center items-center text-background text-2xl bg-primary w-20"
+          >
+            <FaArrowRight />
+          </Link>
         )}
       </div>
-      {pathname === "/user-profile" && (
-        <Link
-          href={`/truck-profile/${sightingData.food_truck_id}`}
-          className=" flex justify-center items-center text-background text-2xl bg-primary w-20"
-        >
-          <FaArrowRight />
-        </Link>
-      )}
-    </div>
+    </Link>
   );
 }


### PR DESCRIPTION
Closes #123 

Applied the styling changes made to the landing page which were accidentally removed last pull request.

Improved the display of the sighting cards and made them display consistently across both truck and profile pages.

Also made the entire div a link and fixed a bug where recent trucks was actually displaying the oldest trucks.

@Yizhen-Zheng The information on the truck profile page seems accurate but on the user profile page we currently don't have access the sighting confirmation data so the info is not displaying correctly.

![image](https://github.com/user-attachments/assets/99be8044-2cae-4246-a724-11835fd21558)

![image](https://github.com/user-attachments/assets/b17a1419-21e4-4a49-b548-bfab58e07082)

This displays as wanted but the information is incorrect (we need confirmation data)
![image](https://github.com/user-attachments/assets/9931e55d-f09a-45eb-a5b3-c5a2406d7425)

 