### PR TITLE
fix: display updated truck info when click a different marker

### DIFF
--- a/components/map/sighting-confirm-card.tsx
+++ b/components/map/sighting-confirm-card.tsx
@@ -43,7 +43,7 @@ export default function SightingConfirmCard({
       setTruck(truck);
     };
     getTruck();
-  }, []);
+  }, [sighting]);
 
   return (
     <div className="relative  w-80 flex flex-col">


### PR DESCRIPTION
Closes #134 

Quick fix which makes it so truck information updates when cycling through confirm sighting popups  